### PR TITLE
memfd: support conversion from an open memfd file

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,12 @@ exclude = [
 ]
 
 [dependencies]
+# Private dependencies.
+libc = "0.2"
+# Public dependencies, exposed through library API.
+either = "1.5"
 errno = "0.2"
 error-chain = {version = "0.12", default-features = false}
-libc = "0.2"
 
 [package.metadata.release]
 sign-commit = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,10 +32,11 @@
 
 #![deny(missing_docs)]
 
+extern crate either;
 extern crate errno;
-extern crate libc;
 #[macro_use]
 extern crate error_chain;
+extern crate libc;
 
 pub mod errors;
 mod memfd;

--- a/tests/memfd.rs
+++ b/tests/memfd.rs
@@ -1,4 +1,5 @@
 extern crate memfd;
+use std::fs;
 use std::os::unix::io::AsRawFd;
 
 #[test]
@@ -23,4 +24,19 @@ fn test_memfd_multi() {
 
     let m0_file = m0.into_file();
     assert_eq!(f0, m0_file.as_raw_fd());
+}
+
+#[test]
+fn test_memfd_from_into() {
+    let opts = memfd::MemfdOptions::default();
+    let m0 = opts.create("default").unwrap();
+    let f0 = m0.into_file();
+    let _ = memfd::Memfd::try_from_file(f0)
+        .left()
+        .expect("failed to convert a legit memfd file");
+
+    let rootdir = fs::File::open("/").unwrap();
+    let _ = memfd::Memfd::try_from_file(rootdir)
+        .right()
+        .expect("unexpected conversion from a non-memfd file");
 }


### PR DESCRIPTION
This adds support for safe conversion of an existing open file into a
memfd object.