### PR TITLE
memfd: prepare for next release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: rust
 
 rust:
   - 1.35.0     # minimum supported toolchain
+  - 1.40.0     # pinned toolchain for clippy
   - stable
   - beta
   - nightly
@@ -12,7 +13,7 @@ matrix:
 
 env:
   global:
-    - CLIPPY_RUST_VERSION=1.35.0
+    - CLIPPY_RUST_VERSION=1.40.0
 
 before_script:
   - bash -c 'if [[ "$TRAVIS_RUST_VERSION" == "$CLIPPY_RUST_VERSION" ]]; then

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "memfd"
 version = "0.3.0-alpha.0"
+edition = "2018"
 authors = [ "Luca Bruno <lucab@debian.org>" ]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/lucab/memfd-rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "memfd"
-version = "0.2.1-alpha.0"
+version = "0.3.0-alpha.0"
 authors = [ "Luca Bruno <lucab@debian.org>" ]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/lucab/memfd-rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,9 +21,8 @@ thiserror = "1"
 
 [package.metadata.release]
 sign-commit = true
-upload-doc = false
 disable-publish = true
 disable-push = true
 pre-release-commit-message = "cargo: memfd release {{version}}"
-pro-release-commit-message = "cargo: version bump to {{version}}"
+post-release-commit-message = "cargo: development version bump"
 tag-message = "memfd {{version}}"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,6 @@ mod memfd;
 mod nr;
 mod sealing;
 
-pub use errors::Error;
-pub use memfd::{HugetlbSize, Memfd, MemfdOptions};
-pub use sealing::{FileSeal, SealsHashSet};
+pub use crate::errors::Error;
+pub use crate::memfd::{HugetlbSize, Memfd, MemfdOptions};
+pub use crate::sealing::{FileSeal, SealsHashSet};

--- a/src/memfd.rs
+++ b/src/memfd.rs
@@ -1,7 +1,7 @@
+use crate::nr;
+use crate::sealing;
 use either;
 use libc;
-use nr;
-use sealing;
 use std::ffi;
 use std::fs;
 use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};


### PR DESCRIPTION
Misc changes:
 * switch to 2018 edition
 * update development version for next release
 * bump clippy toolchain in CI
 * update release metadata for latest `cargo-release`