### PR TITLE
Implement AsRawFd, IntoRawFd for Memfd and allow safe construction from impl AsRawFd + IntoRawFd.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,6 @@ exclude = [
 [dependencies]
 # Private dependencies.
 libc = "0.2"
-# Public dependencies, exposed through library API.
-either = "1.5"
 
 [package.metadata.release]
 sign-commit = true

--- a/src/memfd.rs
+++ b/src/memfd.rs
@@ -1,4 +1,5 @@
-use std::{ffi, fs, os::raw, os::unix::io::{AsRawFd, FromRawFd, RawFd}};
+use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
+use std::{ffi, fs, os::raw};
 use crate::{nr, sealing};
 
 #[cfg(target_os="linux")]
@@ -231,5 +232,17 @@ impl FromRawFd for Memfd {
     unsafe fn from_raw_fd(fd: RawFd) -> Memfd {
         let file = fs::File::from_raw_fd(fd);
         Memfd { file }
+    }
+}
+
+impl AsRawFd for Memfd {
+    fn as_raw_fd(&self) -> RawFd {
+        self.file.as_raw_fd()
+    }
+}
+
+impl IntoRawFd for Memfd {
+    fn into_raw_fd(self) -> RawFd {
+        self.into_file().into_raw_fd()
     }
 }

--- a/src/memfd.rs
+++ b/src/memfd.rs
@@ -172,11 +172,8 @@ impl Memfd {
     /// Otherwise the supplied `File` is returned for further usage.
     ///
     /// [`File`]: fs::File
-    pub fn try_from_file(file: fs::File) -> either::Either<Self, fs::File> {
-        match Self::try_from_fd(file) {
-            Ok(x) => either::Either::Left(x),
-            Err(e) => either::Either::Right(e),
-        }
+    pub fn try_from_file(file: fs::File) -> Result<Self, fs::File> {
+        Self::try_from_fd(file)
     }
 
     /// Return a reference to the backing [`File`].

--- a/tests/memfd.rs
+++ b/tests/memfd.rs
@@ -32,11 +32,9 @@ fn test_memfd_from_into() {
     let m0 = opts.create("default").unwrap();
     let f0 = m0.into_file();
     let _ = memfd::Memfd::try_from_file(f0)
-        .left()
         .expect("failed to convert a legit memfd file");
 
     let rootdir = fs::File::open("/").unwrap();
     let _ = memfd::Memfd::try_from_file(rootdir)
-        .right()
-        .expect("unexpected conversion from a non-memfd file");
+        .expect_err("unexpected conversion from a non-memfd file");
 }


### PR DESCRIPTION
This PR implements `AsRawFd` and `IntoRawFd` for `Memfd`, and adds `Memfd::try_from_fd`.

`try_from_fd` takes an objects that is both `AsRawFd` and `IntoRawFd`. It uses `AsRawFd` to test the file descriptor before calling `IntoRawFd`. Otherwise, we could not return the original object unharmed.

It also uses `Result` as return type rather than `Either`. I think `Result` properly represents the fact that the conversion failed, and it avoids an external dependency. I was thinking to also replace the return value `try_from_file` with `Result`, but that would be a breaking change. Would you be ok with that?

Fixes #11