### PR TITLE
Enable CLOEXEC by default.

### DIFF
--- a/src/memfd.rs
+++ b/src/memfd.rs
@@ -90,7 +90,7 @@ impl Default for MemfdOptions {
     fn default() -> Self {
         Self {
             allow_sealing: false,
-            cloexec: false,
+            cloexec: true,
             hugetlb: None,
         }
     }


### PR DESCRIPTION
As discussed in #17, this PR changes the default for the close-on-exec flag to be enabled, and it allows the flag to be changed after creation.

Also added tests.

Closes #17