### PR TITLE
memfd: clean up linting warnings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@
 //! ```
 #![deny(
     missing_docs,
-    intra_doc_link_resolution_failure,
+    broken_intra_doc_links,
     clippy::all,
     unreachable_pub,
     unused,

--- a/src/memfd.rs
+++ b/src/memfd.rs
@@ -98,6 +98,7 @@ impl Default for MemfdOptions {
 }
 
 /// Page size for a hugetlb anonymous file.
+#[allow(clippy::all)]
 #[derive(Copy, Clone, Debug)]
 pub enum HugetlbSize {
     /// 64KB hugetlb page.


### PR DESCRIPTION
This fixes a couple of linting warnings currently hit on nightly
toolchain.