### PR TITLE
Add support for target_os = android

### DIFF
--- a/.github/workflows/memfd.yml
+++ b/.github/workflows/memfd.yml
@@ -79,3 +79,25 @@ jobs:
         with:
           command: build
           args: --manifest-path=Cargo.toml
+  cross:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target:
+          - arm-linux-androideabi
+          - aarch64-linux-android
+    steps:
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: ${{ matrix.target }}
+          override: true
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Build
+        uses: actions-rs/cargo@v1
+        with:
+          use-cross: true
+          command: build
+          args: --target=${{ matrix.target }} --manifest-path=Cargo.toml

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 
 [dependencies]
 # Private dependencies.
-libc = "0.2"
+libc = "^0.2.99"
 
 [package.metadata.release]
 sign-commit = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,10 +36,10 @@
     unused,
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![cfg_attr(docsrs, doc(cfg(target_os="linux")))]
+#![cfg_attr(docsrs, doc(cfg(any(target_os = "android", target_os= "linux" ))))]
 // No-op crate on platforms that do not support memfd_create, instead of failing to link, or at
 // runtime.
-#![cfg(target_os="linux")]
+#![cfg(any(target_os = "android", target_os= "linux"))]
 
 mod errors;
 mod memfd;

--- a/src/memfd.rs
+++ b/src/memfd.rs
@@ -2,7 +2,7 @@ use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 use std::{ffi, fs, os::raw};
 use crate::{nr, sealing};
 
-#[cfg(target_os="linux")]
+#[cfg(any(target_os = "android", target_os="linux"))]
 unsafe fn memfd_create(name: *const raw::c_char, flags: raw::c_uint) -> raw::c_int {
     libc::syscall(libc::SYS_memfd_create, name, flags) as raw::c_int
 }


### PR DESCRIPTION
Android supports memfds. Add `target_os = android` to the conditional compilation flags. Replace the use of raw libc::syscall` with a more generic `libc::fcntl` calls.

Test are fine on a AOSP Android 9.0:

```sh
~/memfd-rs ‹pr-android*› cargo test --target aarch64-linux-android                                     
   Compiling memfd v0.4.1-alpha.0 (/home/felix/memfd-rs)
    Finished test [unoptimized + debuginfo] target(s) in 0.49s
     Running unittests (target/aarch64-linux-android/debug/deps/memfd-9f7fbfff9cfff8d3)
remount succeeded
+ adb push /home/felix/memfd-rs/target/aarch64-linux-android/debug/deps/memfd-9f7fbfff9cfff8d3 /data
/home/felix/memfd-rs/target/aarch64-linux-android/debug/deps/memfd-9f7fbfff9cfff8d3: 1 file pushed. 21.4 MB/s (5790168 bytes in 0.258s)
+ adb shell /data/memfd-9f7fbfff9cfff8d3

running 1 test
test errors::error_send_sync ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

+ adb shell rm /data/memfd-9f7fbfff9cfff8d3
     Running tests/memfd.rs (target/aarch64-linux-android/debug/deps/memfd-18901d5b48e24950)
remount succeeded
+ adb push /home/felix/memfd-rs/target/aarch64-linux-android/debug/deps/memfd-18901d5b48e24950 /data
/home/felix/memfd-rs/target/aarch64-linux-android/debug/deps/memfd-18901d5b48e24950: 1 file pushed. 21.6 MB/s (6180424 bytes in 0.273s)
+ adb shell /data/memfd-18901d5b48e24950

running 4 tests
test test_memfd_default ... ok
test test_memfd_from_into ... ok
test test_memfd_multi ... ok
test test_memfd_no_cloexec ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s

+ adb shell rm /data/memfd-18901d5b48e24950
     Running tests/sealing.rs (target/aarch64-linux-android/debug/deps/sealing-a99958c7b2daecde)
remount succeeded
+ adb push /home/felix/memfd-rs/target/aarch64-linux-android/debug/deps/sealing-a99958c7b2daecde /data
/home/felix/memfd-rs/target/aarch64-linux-android/debug/deps/sealing-a99958c7b2daecde: 1 file pushed. 21.2 MB/s (6377448 bytes in 0.287s)
+ adb shell /data/sealing-a99958c7b2daecde

running 4 tests
test test_sealing_default ... ok
test test_sealing_add ... ok
test test_sealing_unsealed ... ok
test test_sealing_resize ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

+ adb shell rm /data/sealing-a99958c7b2daecde
```
