### PR TITLE
Update to rustix 0.34.0.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 
 [dependencies]
 # Private dependencies.
-rustix = "0.33.0"
+rustix = "0.34.0"
 
 [package.metadata.release]
 disable-publish = true

--- a/src/memfd.rs
+++ b/src/memfd.rs
@@ -245,6 +245,6 @@ fn is_memfd<F: AsRawFd>(fd: &F) -> bool {
     // SAFETY: For now, we trust the file descriptor returned by `as_raw_fd()`
     // is valid. Once `AsFd` is stabilized in std, we can use that instead of
     // `AsRawFd`, and eliminate this `unsafe` block.
-    let fd = unsafe { rustix::fd::BorrowedFd::borrow_raw_fd(fd.as_raw_fd()) };
+    let fd = unsafe { rustix::fd::BorrowedFd::borrow_raw(fd.as_raw_fd()) };
     rustix::fs::fcntl_get_seals(&fd).is_ok()
 }


### PR DESCRIPTION
This fixes the error in https://github.com/lucab/memfd-rs/pull/30; `BorrowFd::borrow_raw_fd` was renamed to `BorrowFd::borrow_raw` to match the [API in nightly](https://doc.rust-lang.org/nightly/std/os/unix/io/struct.BorrowedFd.html#method.borrow_raw).