### PR TITLE
Add a `SealFutureWrite` flag.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 
 [dependencies]
 # Private dependencies.
-rustix = "0.34.0"
+rustix = "0.34.1"
 
 [package.metadata.release]
 disable-publish = true

--- a/src/sealing.rs
+++ b/src/sealing.rs
@@ -25,6 +25,11 @@ pub enum FileSeal {
     ///
     /// Corresponds to `F_SEAL_SEAL`.
     SealSeal,
+    /// Like `F_SEAL_WRITE`, but may still be written to through pre-existing
+    /// writeable mappings. Introduced in Linux 5.1.
+    ///
+    /// Corresponds to `F_SEAL_FUTURE_WRITE`.
+    SealFutureWrite,
 }
 
 impl FileSeal {
@@ -35,6 +40,7 @@ impl FileSeal {
             FileSeal::SealShrink => SealFlags::SHRINK,
             FileSeal::SealGrow => SealFlags::GROW,
             FileSeal::SealWrite => SealFlags::WRITE,
+            FileSeal::SealFutureWrite => SealFlags::FUTURE_WRITE,
         }
     }
 }
@@ -62,6 +68,9 @@ pub(crate) fn bitflags_to_seals(bitflags: SealFlags) -> SealsHashSet {
     }
     if bitflags.contains(SealFlags::WRITE) {
         sset.insert(FileSeal::SealWrite);
+    }
+    if bitflags.contains(SealFlags::FUTURE_WRITE) {
+        sset.insert(FileSeal::SealFutureWrite);
     }
     sset
 }

--- a/src/sealing.rs
+++ b/src/sealing.rs
@@ -29,6 +29,7 @@ pub enum FileSeal {
     /// writeable mappings. Introduced in Linux 5.1.
     ///
     /// Corresponds to `F_SEAL_FUTURE_WRITE`.
+    #[cfg(any(target_os = "android", target_os = "linux"))]
     SealFutureWrite,
 }
 
@@ -40,6 +41,7 @@ impl FileSeal {
             FileSeal::SealShrink => SealFlags::SHRINK,
             FileSeal::SealGrow => SealFlags::GROW,
             FileSeal::SealWrite => SealFlags::WRITE,
+            #[cfg(any(target_os = "android", target_os = "linux"))]
             FileSeal::SealFutureWrite => SealFlags::FUTURE_WRITE,
         }
     }
@@ -69,6 +71,7 @@ pub(crate) fn bitflags_to_seals(bitflags: SealFlags) -> SealsHashSet {
     if bitflags.contains(SealFlags::WRITE) {
         sset.insert(FileSeal::SealWrite);
     }
+    #[cfg(any(target_os = "android", target_os = "linux"))]
     if bitflags.contains(SealFlags::FUTURE_WRITE) {
         sset.insert(FileSeal::SealFutureWrite);
     }

--- a/tests/sealing.rs
+++ b/tests/sealing.rs
@@ -45,12 +45,15 @@ fn test_sealing_add() {
 
     // `SealFutureWrite` is new as of Linux 5.1, so be prepared for it to fail
     // if we don't have it.
-    let future_write_seal = memfd::SealsHashSet::from_iter(vec![memfd::FileSeal::SealFutureWrite]);
     let mut a3 = a2;
-    if let Ok(()) = m0.add_seal(memfd::FileSeal::SealFutureWrite) {
-        a3 = a3.union(&future_write_seal).cloned().collect();
-        let r3 = m0.seals().unwrap();
-        assert_eq!(r3, a3);
+    #[cfg(any(target_os = "android", target_os = "linux"))]
+    {
+        let future_write_seal = memfd::SealsHashSet::from_iter(vec![memfd::FileSeal::SealFutureWrite]);
+        if let Ok(()) = m0.add_seal(memfd::FileSeal::SealFutureWrite) {
+            a3 = a3.union(&future_write_seal).cloned().collect();
+            let r3 = m0.seals().unwrap();
+            assert_eq!(r3, a3);
+        }
     }
 
     let seal_seal = memfd::SealsHashSet::from_iter(vec![memfd::FileSeal::SealSeal]);

--- a/tests/sealing.rs
+++ b/tests/sealing.rs
@@ -43,11 +43,21 @@ fn test_sealing_add() {
     let r2 = m0.seals().unwrap();
     assert_eq!(r2, a2);
 
+    // `SealFutureWrite` is new as of Linux 5.1, so be prepared for it to fail
+    // if we don't have it.
+    let future_write_seal = memfd::SealsHashSet::from_iter(vec![memfd::FileSeal::SealFutureWrite]);
+    let mut a3 = a2;
+    if let Ok(()) = m0.add_seal(memfd::FileSeal::SealFutureWrite) {
+        a3 = a3.union(&future_write_seal).cloned().collect();
+        let r3 = m0.seals().unwrap();
+        assert_eq!(r3, a3);
+    }
+
     let seal_seal = memfd::SealsHashSet::from_iter(vec![memfd::FileSeal::SealSeal]);
     m0.add_seals(&seal_seal).unwrap();
-    let a3 = a2.union(&seal_seal).cloned().collect();
-    let r3 = m0.seals().unwrap();
-    assert_eq!(r3, a3);
+    let a4 = a3.union(&seal_seal).cloned().collect();
+    let r4 = m0.seals().unwrap();
+    assert_eq!(r4, a4);
 
     // memfd is "seal" sealed, adding further sealing should fail.
     m0.add_seals(&shrink_seal).unwrap_err();


### PR DESCRIPTION
This flag corresponds to Linux's `F_SEAL_FUTURE_WRITE` flag.