### PR TITLE
Release 0.5.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "memfd"
-version = "0.4.2-alpha.0"
+version = "0.5.0"
 edition = "2018"
 authors = [ "Luca Bruno <lucab@lucabruno.net>", "Simonas Kazlauskas <git@kazlauskas.me>" ]
 license = "MIT/Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "memfd"
-version = "0.5.0"
+version = "0.5.1-alpha.0"
 edition = "2018"
 authors = [ "Luca Bruno <lucab@lucabruno.net>", "Simonas Kazlauskas <git@kazlauskas.me>" ]
 license = "MIT/Apache-2.0"


### PR DESCRIPTION
This among other things includes a port to `rustix` which also introduced a breaking change as noted [here](https://github.com/lucab/memfd-rs/pull/27#discussion_r795253006).