### PR TITLE
Change `add_seals` to take an iterator instead of a `&HashSet`.

### DIFF
--- a/examples/sized.rs
+++ b/examples/sized.rs
@@ -18,10 +18,10 @@ fn main() {
     mfd.as_file().set_len(1024).unwrap();
 
     // Add seals to prevent further resizing.
-    let mut seals = memfd::SealsHashSet::new();
-    seals.insert(memfd::FileSeal::SealShrink);
-    seals.insert(memfd::FileSeal::SealGrow);
-    mfd.add_seals(&seals).unwrap();
+    mfd.add_seals(&[
+        memfd::FileSeal::SealShrink,
+        memfd::FileSeal::SealGrow
+    ]).unwrap();
 
     // Prevent further sealing changes.
     mfd.add_seal(memfd::FileSeal::SealSeal).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,10 +17,10 @@
 //!     mfd.as_file().set_len(1024)?;
 //!
 //!     // Add seals to prevent further resizing.
-//!     let mut seals = memfd::SealsHashSet::new();
-//!     seals.insert(memfd::FileSeal::SealShrink);
-//!     seals.insert(memfd::FileSeal::SealGrow);
-//!     mfd.add_seals(&seals)?;
+//!     mfd.add_seals(&[
+//!         memfd::FileSeal::SealShrink,
+//!         memfd::FileSeal::SealGrow
+//!     ])?;
 //!
 //!     // Prevent further sealing changes.
 //!     mfd.add_seal(memfd::FileSeal::SealSeal)?;

--- a/src/memfd.rs
+++ b/src/memfd.rs
@@ -184,15 +184,20 @@ impl Memfd {
 
     /// Add a seal to the existing set of seals.
     pub fn add_seal(&self, seal: sealing::FileSeal) -> Result<(), crate::Error> {
-        use std::iter::FromIterator;
-
-        let set = sealing::SealsHashSet::from_iter(vec![seal]);
-        self.add_seals(&set)
+        let flags = seal.bitflags();
+        self.add_seal_flags(flags)
     }
 
     /// Add some seals to the existing set of seals.
-    pub fn add_seals(&self, seals: &sealing::SealsHashSet) -> Result<(), crate::Error> {
+    pub fn add_seals<'a>(
+        &self,
+        seals: impl IntoIterator<Item = &'a sealing::FileSeal>,
+    ) -> Result<(), crate::Error> {
         let flags = sealing::seals_to_bitflags(seals);
+        self.add_seal_flags(flags)
+    }
+
+    fn add_seal_flags(&self, flags: rustix::fs::SealFlags) -> Result<(), crate::Error> {
         rustix::fs::fcntl_add_seals(&self.file, flags)
             .map_err(Into::into)
             .map_err(crate::Error::AddSeals)?;

--- a/src/sealing.rs
+++ b/src/sealing.rs
@@ -40,9 +40,9 @@ impl FileSeal {
 }
 
 /// Convert a set of seals into a bitflags value.
-pub(crate) fn seals_to_bitflags(set: &SealsHashSet) -> SealFlags {
+pub(crate) fn seals_to_bitflags<'a>(seals: impl IntoIterator<Item = &'a FileSeal>) -> SealFlags {
     let mut bits = SealFlags::empty();
-    for seal in set.iter() {
+    for seal in seals {
         bits |= seal.bitflags();
     }
     bits


### PR DESCRIPTION
Generalize `Memfd::add_seals` to take an iterator instead of a
`&HashSet`. This way, users can still pass in a `&HashSet` if they have
one, but they can also pass in a simple slice, which is more convenient.

This also updates the examples in examples/sized.rs and src/lib.rs to
use slices, which is easier to read. These changes aren't strictly
necessary, because the old code would still work.
