### PR TITLE
0.6.0 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "memfd"
-version = "0.5.2-alpha.0"
+version = "0.6.0"
 edition = "2018"
 authors = [
     "Luca Bruno <lucab@lucabruno.net>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "memfd"
-version = "0.6.0"
+version = "0.6.1-alpha.0"
 edition = "2018"
 authors = [
     "Luca Bruno <lucab@lucabruno.net>",


### PR DESCRIPTION
Took me a while to find an example that demonstrates the breaking change but [I managed to do it](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=6513ee2b6cb67a2f0c1d79041ecba0b0) in the end, so 0.6.0 is it.