### PR TITLE
Update to rustix-0.35.6.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = [".gitignore", ".travis.yml"]
 
 [dependencies]
 # Private dependencies.
-rustix = "0.34.1"
+rustix = { version = "0.35.6", features = ["fs"] }
 
 [package.metadata.release]
 disable-publish = true


### PR DESCRIPTION
This makes cargo build from a clean memfd-rs tree about 15% faster.