### PR TITLE
cargo: update to rustix 0.36

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = [".gitignore", ".travis.yml"]
 
 [dependencies]
 # Private dependencies.
-rustix = { version = "0.35.6", features = ["fs"] }
+rustix = { version = "0.36.0", features = ["fs"] }
 
 [package.metadata.release]
 disable-publish = true

--- a/src/memfd.rs
+++ b/src/memfd.rs
@@ -248,5 +248,5 @@ fn is_memfd<F: AsRawFd>(fd: &F) -> bool {
     // is valid. Once `AsFd` is stabilized in std, we can use that instead of
     // `AsRawFd`, and eliminate this `unsafe` block.
     let fd = unsafe { rustix::fd::BorrowedFd::borrow_raw(fd.as_raw_fd()) };
-    rustix::fs::fcntl_get_seals(&fd).is_ok()
+    rustix::fs::fcntl_get_seals(fd).is_ok()
 }

--- a/src/memfd.rs
+++ b/src/memfd.rs
@@ -70,9 +70,7 @@ impl MemfdOptions {
         let fd = rustix::fs::memfd_create(name.as_ref(), flags)
             .map_err(Into::into)
             .map_err(crate::Error::Create)?;
-        Ok(Memfd {
-            file: rustix::fd::FromFd::from_fd(fd.into()),
-        })
+        Ok(Memfd { file: fd.into() })
     }
 }
 


### PR DESCRIPTION
This is a minor update; the main change is that it uses io-lifetimes 1.0 internally, which means that on Rust 1.64 and later it's using the `OwnedFd` etc. from std instead of its own. This is not exposed in memfd's public API.

Closes: https://github.com/lucab/memfd-rs/pull/43