### PR TITLE
docs: fix close-on-exec default value

### DIFF
--- a/src/memfd.rs
+++ b/src/memfd.rs
@@ -16,7 +16,7 @@ impl MemfdOptions {
     ///
     /// The default options are:
     ///  * [`FileSeal::SealSeal`] (i.e. no further sealing);
-    ///  * close-on-exec is disabled;
+    ///  * close-on-exec is enabled;
     ///  * hugetlb is disabled.
     ///
     /// [`FileSeal::SealSeal`]: sealing::FileSeal::SealSeal


### PR DESCRIPTION
CLOEXEC is enabled by default but the docs say the opposite
Closes #45  

