### PR TITLE
cargo: bump MSRV to 1.85

### DIFF
--- a/.github/workflows/memfd.yml
+++ b/.github/workflows/memfd.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust_toolchain: [nightly, stable, 1.63.0]
+        rust_toolchain: [nightly, stable, 1.85]
     timeout-minutes: 20
     steps:
       - name: Install Rust ${{ matrix.rust_toolchain }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ description = "A pure-Rust library to work with Linux memfd and sealing"
 keywords = ["Linux", "memfd", "memfd_create", "seal"]
 categories = ["filesystem", "os", "os::unix-apis"]
 exclude = [".gitignore", ".travis.yml"]
+rust-version = "1.85"
 
 [dependencies]
 # Private dependencies.


### PR DESCRIPTION
This is in preparation for the switch to https://doc.rust-lang.org/edition-guide/rust-2024/index.html.