### PR TITLE
docs: tweaks links and fix related warning

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,10 +30,10 @@
 //! ```
 #![deny(
     missing_docs,
-    broken_intra_doc_links,
-    clippy::all,
     unreachable_pub,
-    unused
+    unused,
+    clippy::all,
+    rustdoc::broken_intra_doc_links
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(docsrs, doc(cfg(any(target_os = "android", target_os = "linux"))))]

--- a/src/memfd.rs
+++ b/src/memfd.rs
@@ -3,7 +3,7 @@ use rustix::fs::{MemfdFlags, SealFlags};
 use std::fs;
 use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 
-/// A `Memfd` builder, providing advanced options and flags for specifying its behavior.
+/// A [`Memfd`] builder, providing advanced options and flags for specifying its behavior.
 #[derive(Clone, Debug)]
 pub struct MemfdOptions {
     allow_sealing: bool,
@@ -12,7 +12,7 @@ pub struct MemfdOptions {
 }
 
 impl MemfdOptions {
-    /// Default set of options for `Memfd` creation.
+    /// Default set of options for [`Memfd`] creation.
     ///
     /// The default options are:
     ///  * [`FileSeal::SealSeal`] (i.e. no further sealing);
@@ -63,8 +63,6 @@ impl MemfdOptions {
     }
 
     /// Create a [`Memfd`] according to configuration.
-    ///
-    /// [`Memfd`]: Memfd
     pub fn create<T: AsRef<str>>(&self, name: T) -> Result<Memfd, crate::Error> {
         let flags = self.bitflags();
         let fd = rustix::fs::memfd_create(name.as_ref(), flags)
@@ -219,8 +217,6 @@ impl FromRawFd for Memfd {
     /// # Safety
     ///
     /// `fd` must be a valid file descriptor representing a memfd file.
-    ///
-    /// [`Memfd`]: Memfd
     unsafe fn from_raw_fd(fd: RawFd) -> Self {
         unsafe {
             let file = fs::File::from_raw_fd(fd);

--- a/src/sealing.rs
+++ b/src/sealing.rs
@@ -1,7 +1,7 @@
 use rustix::fs::SealFlags;
 use std::collections::HashSet;
 
-/// An `HashSet` specialized on `FileSeal`.
+/// An [`HashSet`] specialized on [`FileSeal`].
 pub type SealsHashSet = HashSet<FileSeal>;
 
 /// Seal that can be applied to a [`Memfd`].


### PR DESCRIPTION
This fixes the following warning:
```
warning: lint `broken_intra_doc_links` has been renamed to `rustdoc::broken_intra_doc_links`
```
Plus, it tweaks and adds some links for easier navigation.