### PR TITLE
lib: add support for `F_SEAL_EXEC`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ rust-version = "1.85"
 
 [dependencies]
 # Private dependencies.
-rustix = { version = "1.0", features = ["fs"] }
+rustix = { version = "1.1", features = ["fs"] }
 
 [package.metadata.release]
 publish = false

--- a/src/sealing.rs
+++ b/src/sealing.rs
@@ -8,6 +8,7 @@ pub type SealsHashSet = HashSet<FileSeal>;
 ///
 /// [`Memfd`]: crate::Memfd
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[non_exhaustive]
 pub enum FileSeal {
     /// File cannot be reduced in size.
     ///
@@ -31,6 +32,14 @@ pub enum FileSeal {
     /// Corresponds to `F_SEAL_FUTURE_WRITE`.
     #[cfg(any(target_os = "android", target_os = "linux"))]
     SealFutureWrite,
+    /// File executable bits cannot be changed.
+    ///
+    /// This prevents modification of any of executable bits (`S_IXUSR`, `S_IXGRP`,
+    /// or `S_IXOTH`), by `chmod(2)` and similar. Introduced in Linux 6.3.
+    ///
+    /// Corresponds to `F_SEAL_EXEC`.
+    #[cfg(any(target_os = "android", target_os = "linux"))]
+    SealExec,
 }
 
 impl FileSeal {
@@ -43,6 +52,8 @@ impl FileSeal {
             Self::SealWrite => SealFlags::WRITE,
             #[cfg(any(target_os = "android", target_os = "linux"))]
             Self::SealFutureWrite => SealFlags::FUTURE_WRITE,
+            #[cfg(any(target_os = "android", target_os = "linux"))]
+            Self::SealExec => SealFlags::EXEC,
         }
     }
 }
@@ -74,6 +85,10 @@ pub(crate) fn bitflags_to_seals(bitflags: SealFlags) -> SealsHashSet {
     #[cfg(any(target_os = "android", target_os = "linux"))]
     if bitflags.contains(SealFlags::FUTURE_WRITE) {
         sset.insert(FileSeal::SealFutureWrite);
+    }
+    #[cfg(any(target_os = "android", target_os = "linux"))]
+    if bitflags.contains(SealFlags::EXEC) {
+        sset.insert(FileSeal::SealExec);
     }
     sset
 }


### PR DESCRIPTION
This adds support for the new `F_SEAL_EXEC` flag for `fcntl(2)` on Linux. 
It has been introduced in Linux kernel 6.3: https://github.com/torvalds/linux/commit/6fd7353829cafc4067aad9eea0dc95da67e7df16.
This bumps the `rustix` dependency in order to pick up https://github.com/bytecodealliance/rustix/pull/1417. It also marks the enum as `non_exhaustive` in order to allow new variants in the future.
