### PR TITLE
memfd: autodetect `noexec_seal` support and use as default creation mode

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,6 @@ mod sealing;
 
 pub use crate::{
     errors::Error,
-    memfd::{HugetlbSize, Memfd, MemfdOptions},
+    memfd::{HugetlbSize, Memfd, MemfdOptions, NoexecSealMode},
     sealing::{FileSeal, SealsHashSet},
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,7 @@
 
 mod errors;
 mod memfd;
+pub mod runtime;
 mod sealing;
 
 pub use crate::{

--- a/src/memfd.rs
+++ b/src/memfd.rs
@@ -16,12 +16,14 @@ pub struct MemfdOptions {
     allow_sealing: bool,
     cloexec: bool,
     hugetlb: Option<HugetlbSize>,
+    noexec_seal: NoexecSealMode,
 }
 
 impl MemfdOptions {
     /// Default set of options for [`Memfd`] creation.
     ///
     /// The default options are:
+    ///  * (if the kernel supports it) `noexec_seal`  is enforced on creation;
     ///  * sealing is allowed;
     ///  * close-on-exec is enabled;
     ///  * hugetlb is disabled.
@@ -30,6 +32,7 @@ impl MemfdOptions {
             allow_sealing: true,
             cloexec: true,
             hugetlb: None,
+            noexec_seal: NoexecSealMode::ProbeAndSetNoexecSeal,
         }
     }
 
@@ -51,6 +54,12 @@ impl MemfdOptions {
         self
     }
 
+    /// Whether to enable optional `noexec_seal` support for the created `Memfd`.
+    pub const fn noexec_seal(mut self, mode: NoexecSealMode) -> Self {
+        self.noexec_seal = mode;
+        self
+    }
+
     /// Translate the current options into a bitflags value for `memfd_create`.
     fn bitflags(&self) -> MemfdFlags {
         let mut bits = MemfdFlags::empty();
@@ -64,12 +73,38 @@ impl MemfdOptions {
             bits |= hugetlb.bitflags();
             bits |= MemfdFlags::HUGETLB;
         }
+        match self.noexec_seal {
+            NoexecSealMode::SetNoexecSeal => {
+                bits |= MemfdFlags::NOEXEC_SEAL;
+                bits |= MemfdFlags::ALLOW_SEALING;
+            }
+            NoexecSealMode::SetExec => {
+                bits |= MemfdFlags::EXEC;
+            }
+            NoexecSealMode::ProbeAndSetNoexecSeal => {
+                if crate::runtime::create_noexec_supported() {
+                    bits |= MemfdFlags::NOEXEC_SEAL;
+                    bits |= MemfdFlags::ALLOW_SEALING;
+                }
+            }
+            NoexecSealMode::ProbeAndSetExec => {
+                if crate::runtime::create_noexec_supported() {
+                    bits |= MemfdFlags::EXEC;
+                }
+            }
+            NoexecSealMode::None => {}
+        }
         bits
     }
 
     /// Create a [`Memfd`] according to configuration.
     pub fn create<T: AsRef<str>>(&self, name: T) -> Result<Memfd, crate::Error> {
         let flags = self.bitflags();
+        if flags.contains(MemfdFlags::NOEXEC_SEAL) && !self.allow_sealing {
+            return Err(crate::Error::Create(std::io::Error::other(
+                "cannot enable MFD_NOEXEC_SEAL and disable MFD_ALLOW_SEALING at the same time",
+            )));
+        }
         let fd = Self::create_inner(name.as_ref(), flags)?;
         Ok(Memfd { file: fd.into() })
     }
@@ -85,6 +120,21 @@ impl Default for MemfdOptions {
     fn default() -> Self {
         Self::new()
     }
+}
+
+/// Execution and sealing mode for [`Memfd`] creation.
+#[derive(Copy, Clone, Debug)]
+pub enum NoexecSealMode {
+    /// Always set the `MFD_NOEXEC_SEAL` flag on creation.
+    SetNoexecSeal,
+    /// Always set the `MFD_EXEC` flag on creation.
+    SetExec,
+    /// Probe if the kernel supports `MFD_NOEXEC_SEAL` and set it on creation if supported.
+    ProbeAndSetNoexecSeal,
+    /// Probe if the kernel supports `MFD_EXEC` and set it on creation if supported.
+    ProbeAndSetExec,
+    /// Do not set any `MFD_NOEXEC_SEAL` or `MFD_EXEC` flags on creation.
+    None,
 }
 
 /// Page size for a hugetlb anonymous file.

--- a/src/memfd.rs
+++ b/src/memfd.rs
@@ -72,10 +72,14 @@ impl MemfdOptions {
     /// Create a [`Memfd`] according to configuration.
     pub fn create<T: AsRef<str>>(&self, name: T) -> Result<Memfd, crate::Error> {
         let flags = self.bitflags();
-        let fd = rustix::fs::memfd_create(name.as_ref(), flags)
-            .map_err(Into::into)
-            .map_err(crate::Error::Create)?;
+        let fd = Self::create_inner(name.as_ref(), flags)?;
         Ok(Memfd { file: fd.into() })
+    }
+
+    pub(crate) fn create_inner(name: &str, flags: MemfdFlags) -> Result<OwnedFd, crate::Error> {
+        rustix::fs::memfd_create(name, flags)
+            .map_err(Into::into)
+            .map_err(crate::Error::Create)
     }
 }
 
@@ -263,6 +267,6 @@ impl From<Memfd> for OwnedFd {
 ///
 /// Implemented by trying to retrieve the seals.
 /// If that fails, the fd is not a memfd.
-fn check_memfd_seals<F: AsFd>(fd: &F) -> bool {
+pub(crate) fn check_memfd_seals<F: AsFd>(fd: &F) -> bool {
     rustix::fs::fcntl_get_seals(fd).is_ok()
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1,0 +1,43 @@
+//! Detect kernel features at runtime.
+//!
+//! This module exposes methods to detect kernel features at runtime.
+//! This allows applications to auto-detect whether recent options are supported by the currently running kernel.
+
+use std::sync::OnceLock;
+
+use rustix::fs::MemfdFlags;
+
+use crate::MemfdOptions;
+
+static NOEXEC_SEAL_SUPPORTED: OnceLock<bool> = OnceLock::new();
+
+/// Returns whether the `MFD_NOEXEC_SEAL`/`MFD_EXEC` flags are supported by the current kernel.
+/// 
+/// This has been introduced in Linux kernel 6.3, and allows controlling the `exec` permission
+/// bits when creating a memfd.
+/// 
+/// See <https://docs.kernel.org/userspace-api/mfd_noexec.html> for more details.
+pub fn create_noexec_supported() -> bool {
+    *NOEXEC_SEAL_SUPPORTED.get_or_init(|| {
+        let flags = MemfdFlags::CLOEXEC | MemfdFlags::NOEXEC_SEAL;
+        MemfdOptions::create_inner("memfd-rs-noexec-seal-probe", flags).is_ok()
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_noexec_seal_supported() {
+        let flags = MemfdFlags::CLOEXEC | MemfdFlags::NOEXEC_SEAL;
+        let res = MemfdOptions::create_inner("probe-test", flags);
+        let is_supported = create_noexec_supported();
+        assert_eq!(res.is_ok(), is_supported);
+
+        if is_supported {
+            let mfd = res.unwrap();
+            assert!(crate::memfd::check_memfd_seals(&mfd));
+        }
+    }
+}

--- a/tests/sealing.rs
+++ b/tests/sealing.rs
@@ -2,19 +2,44 @@ extern crate memfd;
 use std::iter::FromIterator;
 
 #[test]
-fn test_sealing_default() {
+fn test_default() {
     let opts = memfd::MemfdOptions::default();
     let m0 = opts.create("default").unwrap();
     let sset = m0.seals().unwrap();
-    assert_eq!(sset.len(), 0);
+    if memfd::runtime::create_noexec_supported() {
+        let expected = memfd::SealsHashSet::from_iter(vec![memfd::FileSeal::SealExec]);
+        assert_eq!(sset, expected);
+    }
 }
 
 #[test]
-fn test_sealing_unsealed() {
-    let opts = memfd::MemfdOptions::default();
-    let m0 = opts.allow_sealing(true).create("default").unwrap();
+fn test_exec_no_sealing() {
+    if !memfd::runtime::create_noexec_supported() {
+        return;
+    }
+
+    let opts = memfd::MemfdOptions::default()
+        .noexec_seal(memfd::NoexecSealMode::SetExec)
+        .allow_sealing(false);
+    let m0 = opts.create("exec").unwrap();
     let sset = m0.seals().unwrap();
-    assert_eq!(sset.len(), 0);
+    let expected = memfd::SealsHashSet::from_iter(vec![memfd::FileSeal::SealSeal]);
+    assert_eq!(sset, expected);
+}
+
+#[test]
+fn test_noexec_seal() {
+    if !memfd::runtime::create_noexec_supported() {
+        return;
+    }
+
+    let opts = memfd::MemfdOptions::default()
+        .noexec_seal(memfd::NoexecSealMode::SetNoexecSeal)
+        .allow_sealing(true);
+    let m0 = opts.create("noexec").unwrap();
+    let sset = m0.seals().unwrap();
+    let expected = memfd::SealsHashSet::from_iter(vec![memfd::FileSeal::SealExec]);
+    assert_eq!(sset, expected);
 }
 
 #[test]
@@ -22,11 +47,11 @@ fn test_sealing_add() {
     let opts = memfd::MemfdOptions::default();
     let m0 = opts.allow_sealing(true).create("default").unwrap();
     let sset = m0.seals().unwrap();
-    assert_eq!(sset.len(), 0);
+    assert!(!sset.contains(&memfd::FileSeal::SealSeal));
 
     let write_seal = memfd::SealsHashSet::from_iter(vec![memfd::FileSeal::SealWrite]);
     m0.add_seal(memfd::FileSeal::SealWrite).unwrap();
-    let a0 = write_seal;
+    let a0 = sset.union(&write_seal).cloned().collect();
     let r0 = m0.seals().unwrap();
     assert_eq!(r0, a0);
 


### PR DESCRIPTION
This wires the auto-detection logic in https://github.com/lucab/memfd-rs/pull/88 to `MemfdOptions`.
By default, we now try to auto-detect `MFD_NOEXEC_SEAL` kernel-support and directly try to create new FDs in the "noexec" mode.
If the kernel doesn't support this feature, we don't pass any flags and thus we let the kernel pick up the default mode (which can be configured via the `vm.memfd_noexec` sysctl).
This is configurable, and the caller can opt-in for both the "exec" and "no-exec" modes, either unconditionally or based on runtime kernel support probing. 

The matrix of cases is thus the following:
 * `SetNoexecSeal`: unconditionally set `MFD_NOEXEC_SEAL`; creation may fail on older kernels.
 * `SetExec`:  unconditionally set `MFD_EXEC`; creation may fail on older kernels.
 * `ProbeAndSetNoexecSeal`: probe kernel support, if available set `MFD_NOEXEC_SEAL` (otherwise ignore-and-continue); this is the new default.
 * `ProbeAndSetExec`: probe kernel support, if available set `MFD_NOEXEC` (otherwise ignore-and-continue).
 * `None`: no additional flag is set, kernel picks the default mode. On newer kernels, the default is dynamic and controlled by a sysctl-knob.
