### PR TITLE
runtime: add dynamic detection for `MFD_NOEXEC_SEAL`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,7 @@
 
 mod errors;
 mod memfd;
+pub mod runtime;
 mod sealing;
 
 pub use crate::{

--- a/src/memfd.rs
+++ b/src/memfd.rs
@@ -72,10 +72,14 @@ impl MemfdOptions {
     /// Create a [`Memfd`] according to configuration.
     pub fn create<T: AsRef<str>>(&self, name: T) -> Result<Memfd, crate::Error> {
         let flags = self.bitflags();
-        let fd = rustix::fs::memfd_create(name.as_ref(), flags)
-            .map_err(Into::into)
-            .map_err(crate::Error::Create)?;
+        let fd = Self::create_inner(name.as_ref(), flags)?;
         Ok(Memfd { file: fd.into() })
+    }
+
+    pub(crate) fn create_inner(name: &str, flags: MemfdFlags) -> Result<OwnedFd, crate::Error> {
+        rustix::fs::memfd_create(name, flags)
+            .map_err(Into::into)
+            .map_err(crate::Error::Create)
     }
 }
 
@@ -263,6 +267,6 @@ impl From<Memfd> for OwnedFd {
 ///
 /// Implemented by trying to retrieve the seals.
 /// If that fails, the fd is not a memfd.
-fn check_memfd_seals<F: AsFd>(fd: &F) -> bool {
+pub(crate) fn check_memfd_seals<F: AsFd>(fd: &F) -> bool {
     rustix::fs::fcntl_get_seals(fd).is_ok()
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1,0 +1,43 @@
+//! Detect kernel features at runtime.
+//!
+//! This module exposes methods to detect kernel features at runtime.
+//! This allows applications to auto-detect whether recent options are supported by the currently running kernel.
+
+use std::sync::OnceLock;
+
+use rustix::fs::MemfdFlags;
+
+use crate::MemfdOptions;
+
+static NOEXEC_SEAL_SUPPORTED: OnceLock<bool> = OnceLock::new();
+
+/// Returns whether the `MFD_NOEXEC_SEAL`/`MFD_EXEC` flags are supported by the current kernel.
+/// 
+/// This has been introduced in Linux kernel 6.3, and allows controlling the `exec` permission
+/// bits when creating a memfd.
+/// 
+/// See <https://docs.kernel.org/userspace-api/mfd_noexec.html> for more details.
+pub fn create_noexec_supported() -> bool {
+    *NOEXEC_SEAL_SUPPORTED.get_or_init(|| {
+        let flags = MemfdFlags::CLOEXEC | MemfdFlags::NOEXEC_SEAL;
+        MemfdOptions::create_inner("memfd-rs-noexec-seal-probe", flags).is_ok()
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_noexec_seal_supported() {
+        let flags = MemfdFlags::CLOEXEC | MemfdFlags::NOEXEC_SEAL;
+        let res = MemfdOptions::create_inner("probe-test", flags);
+        let is_supported = create_noexec_supported();
+        assert_eq!(res.is_ok(), is_supported);
+
+        if is_supported {
+            let mfd = res.unwrap();
+            assert!(crate::memfd::check_memfd_seals(&mfd));
+        }
+    }
+}


### PR DESCRIPTION
This adds a new `runtime::create_noexec_supported()` helper to runtime-probe the kernel for `MFD_NOEXEC_SEAL` support.