### PR TITLE
memfd: change default allow-sealing mode

### DIFF
--- a/src/memfd.rs
+++ b/src/memfd.rs
@@ -22,14 +22,12 @@ impl MemfdOptions {
     /// Default set of options for [`Memfd`] creation.
     ///
     /// The default options are:
-    ///  * [`FileSeal::SealSeal`] (i.e. no further sealing);
+    ///  * sealing is allowed;
     ///  * close-on-exec is enabled;
     ///  * hugetlb is disabled.
-    ///
-    /// [`FileSeal::SealSeal`]: sealing::FileSeal::SealSeal
     pub const fn new() -> Self {
         Self {
-            allow_sealing: false,
+            allow_sealing: true,
             cloexec: true,
             hugetlb: None,
         }

--- a/tests/sealing.rs
+++ b/tests/sealing.rs
@@ -6,8 +6,7 @@ fn test_sealing_default() {
     let opts = memfd::MemfdOptions::default();
     let m0 = opts.create("default").unwrap();
     let sset = m0.seals().unwrap();
-    let default = memfd::SealsHashSet::from_iter(vec![memfd::FileSeal::SealSeal]);
-    assert_eq!(sset, default);
+    assert_eq!(sset.len(), 0);
 }
 
 #[test]


### PR DESCRIPTION
This switches the default `MemfdOptions::allow_sealing` mode to `true`, breaking with previous releases where this was `false`.
The goal is to align our defaults for the security improvement that will come from `MFD_NOEXEC_SEAL`.
The full reasoning is that, in order to adopt a "noexec" default on creation, we also need to allow sealing as the two concepts are not fully orthogonal: secure "noexec" creation also adds an automatic `SEAL_EXEC`, thus enabling sealing by default too.
As such, here we re-align our default according to kernel choices.