### PR TITLE
[0.6.x] ci: minor tweaks for release branches

### DIFF
--- a/.github/workflows/memfd.yml
+++ b/.github/workflows/memfd.yml
@@ -1,13 +1,19 @@
+---
 name: Test memfd
 
-on:
+'on':
   push:
     paths-ignore:
     - '*.md'
     branches:
-    - master
+      - 'main'
+      - 'master'
+      - 'release/**'
   pull_request:
-    types: [opened, repoened, synchronize]
+    types: [opened, reopened, synchronize]
+  workflow_dispatch:
+
+permissions: {}
 
 jobs:
   native-test:


### PR DESCRIPTION
Backport of https://github.com/lucab/memfd-rs/pull/92 to `release/0.6.x` branch.